### PR TITLE
Improve typing of Service response

### DIFF
--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -165,7 +165,7 @@ namespace ROS2
 
     /// <summary> Create a service for this node for a given topic, callback, qos and message type </summary>
     /// <see cref="INode.CreateService"/>
-    public Service<I, O> CreateService<I, O>(string topic, Action<I> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new()
+    public Service<I, O> CreateService<I, O>(string topic, Func<I, O> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new()
     {
       lock (mutex)
       {

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -165,7 +165,7 @@ namespace ROS2
 
     /// <summary> Create a service for this node for a given topic, callback, qos and message type </summary>
     /// <see cref="INode.CreateService"/>
-    public Service<T> CreateService<T>(string topic, Action<T> callback, QualityOfServiceProfile qos = null) where T : Message, new()
+    public Service<I, O> CreateService<I, O>(string topic, Action<I> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new()
     {
       lock (mutex)
       {
@@ -175,7 +175,7 @@ namespace ROS2
           return null;
         }
 
-        Service<T> service = new Service<T>(topic, this, callback, qos);
+        Service<I, O> service = new Service<I, O>(topic, this, callback, qos);
         services.Add(service);
         logger.LogInfo("Created service for topic " + topic);
         return service;

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -19,7 +19,9 @@ namespace ROS2
 {
   /// <summary> Service to a topic with a given type </summary>
   /// <description> Services are created through INode interface (CreateService) </description>
-  public class Service<T>: IService<T> where T : Message, new ()
+  public class Service<I, O>: IService<I, O>
+    where I : Message, new ()
+    where O : Message, new ()
   {
     public rcl_service_t Handle { get { return serviceHandle; } }
     private rcl_service_t serviceHandle;
@@ -31,7 +33,7 @@ namespace ROS2
     private bool disposed = false;
 
     private rcl_node_t nodeHandle;
-    private readonly Action<T> callback;
+    private readonly Action<I> callback;
     private IntPtr serviceOptions;
 
     public object Mutex { get { return mutex; } }
@@ -41,11 +43,12 @@ namespace ROS2
 
     /// <summary> Tries to send a response message to rcl/rmw layers. </summary>
     // TODO(adamdbrw) this should not be public - add an internal interface
-    public void SendResp(IntPtr valp)
+    public void SendResp(O msg)
     {
       RCLReturnEnum ret;
-
-      ret = (RCLReturnEnum)NativeRcl.rcl_send_response(ref serviceHandle, ref request_header,  ref valp);
+      MessageInternals msgInternals = msg as MessageInternals;
+      msgInternals.WriteNativeMessage();
+      ret = (RCLReturnEnum)NativeRcl.rcl_send_response(ref serviceHandle, ref request_header, msgInternals.Handle);
     }
 
     /// <summary> Tries to get a request message from rcl/rmw layers. Calls the callback if successful </summary>
@@ -77,7 +80,7 @@ namespace ROS2
     /// <summary> Construct a message of the subscription type </summary>
     private MessageInternals CreateMessage()
     {
-      return new T() as MessageInternals;
+      return new I() as MessageInternals;
     }
 
     /// <summary> Populates managed fields with native values and calls the callback with created message </summary>
@@ -85,12 +88,12 @@ namespace ROS2
     private void TriggerCallback(MessageInternals message)
     {
       message.ReadNativeMessage();
-      callback((T)message);
+      callback((I)message);
     }
 
     /// <summary> Internal constructor for Service. Use INode.CreateService to construct </summary>
     /// <see cref="INode.CreateService"/>
-    internal Service(string subTopic, Node node, Action<T> cb, QualityOfServiceProfile qos = null)
+    internal Service(string subTopic, Node node, Action<I> cb, QualityOfServiceProfile qos = null)
     {
       callback = cb;
       nodeHandle = node.nodeHandle;
@@ -106,7 +109,7 @@ namespace ROS2
 
       serviceOptions = NativeRclInterface.rclcs_service_create_options(qualityOfServiceProfile.handle);
 
-      T msg = new T();
+      I msg = new I();
       MessageInternals msgInternals = msg as MessageInternals;
       IntPtr typeSupportHandle = msgInternals.TypeSupportHandle;
       msg.Dispose();

--- a/src/ros2cs/ros2cs_core/interfaces/INode.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/INode.cs
@@ -45,7 +45,7 @@ namespace ROS2
     /// <param name="callback"> Action to be called when message is received (through Spin or SpinOnce). Provide a lambda or a method </param>
     /// <param name="qos"> Quality of Service settings. Not passing this parameter will result in default settings </param>
     /// <returns> Service for the topic </returns>
-    Service<I, O> CreateService<I, O>(string topic, Action<I> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
+    Service<I, O> CreateService<I, O>(string topic, Func<I, O> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a service </summary>
     /// <remarks> Note that this does not call Dispose on Service </remarks>

--- a/src/ros2cs/ros2cs_core/interfaces/INode.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/INode.cs
@@ -45,7 +45,7 @@ namespace ROS2
     /// <param name="callback"> Action to be called when message is received (through Spin or SpinOnce). Provide a lambda or a method </param>
     /// <param name="qos"> Quality of Service settings. Not passing this parameter will result in default settings </param>
     /// <returns> Service for the topic </returns>
-    Service<T> CreateService<T>(string topic, Action<T> callback, QualityOfServiceProfile qos = null) where T : Message, new();
+    Service<I, O> CreateService<I, O>(string topic, Action<I> callback, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a service </summary>
     /// <remarks> Note that this does not call Dispose on Service </remarks>

--- a/src/ros2cs/ros2cs_core/interfaces/IService.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IService.cs
@@ -21,9 +21,6 @@ namespace ROS2
   public interface IServiceBase : IExtendedDisposable
   {
     // TODO(adamdbrw) this should not be public - add an internal interface
-    void SendResp(IntPtr valp);
-
-    // TODO(adamdbrw) this should not be public - add an internal interface
     void TakeMessage();
 
     /// <summary> topic name which was used when calling Ros2cs.CreateService </summary>
@@ -37,5 +34,10 @@ namespace ROS2
   }
 
   /// <summary> Generic base interface for all services </summary>
-  public interface IService<T>: IServiceBase where T: Message {}
+  public interface IService<I, O>: IServiceBase
+    where I: Message
+    where O: Message
+  {
+    void SendResp(O msg);
+  }
 }

--- a/src/ros2cs/ros2cs_core/interfaces/IService.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IService.cs
@@ -37,7 +37,5 @@ namespace ROS2
   public interface IService<I, O>: IServiceBase
     where I: Message
     where O: Message
-  {
-    void SendResp(O msg);
-  }
+  {}
 }

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -243,7 +243,7 @@ namespace ROS2
         typeof(TakeRequestType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int SendResponceType( ref rcl_service_t service, ref rcl_rmw_request_id_t request_header, ref IntPtr responce_info);
+    internal delegate int SendResponceType( ref rcl_service_t service, ref rcl_rmw_request_id_t request_header, IntPtr responce_info);
     internal static SendResponceType
         rcl_send_response =
         (SendResponceType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(

--- a/src/ros2cs/ros2cs_examples/ROS2Service.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Service.cs
@@ -30,18 +30,18 @@ namespace Examples
       Ros2cs.Init();
       INode node = Ros2cs.CreateNode("service");
       my_service = node.CreateService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>(
-        "add_two_ints", msg => { recv_callback (msg);});
+        "add_two_ints", recv_callback);
 
       Ros2cs.Spin(node);
       Ros2cs.Shutdown();
     }
 
-    public static void recv_callback ( example_interfaces.srv.AddTwoInts_Request msg )
+    public static example_interfaces.srv.AddTwoInts_Response recv_callback ( example_interfaces.srv.AddTwoInts_Request msg )
     {
       Console.WriteLine ("Incoming Service Request A=" + msg.A + " B=" + msg.B);
       example_interfaces.srv.AddTwoInts_Response response = new example_interfaces.srv.AddTwoInts_Response();
       response.Sum = msg.A + msg.B;
-      my_service.SendResp(response);
+      return response;
     }
   }
 }

--- a/src/ros2cs/ros2cs_examples/ROS2Service.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Service.cs
@@ -22,14 +22,14 @@ namespace Examples
   /// <summary> A simple service class to illustrate Ros2cs in action </summary>
   public class ROS2Service
   {
-    public static IService<example_interfaces.srv.AddTwoInts_Request> my_service;
+    public static IService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_service;
 
     public static void Main(string[] args)
     {
       Console.WriteLine("Service start");
       Ros2cs.Init();
       INode node = Ros2cs.CreateNode("service");
-      my_service = node.CreateService<example_interfaces.srv.AddTwoInts_Request>(
+      my_service = node.CreateService<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>(
         "add_two_ints", msg => { recv_callback (msg);});
 
       Ros2cs.Spin(node);
@@ -38,10 +38,10 @@ namespace Examples
 
     public static void recv_callback ( example_interfaces.srv.AddTwoInts_Request msg )
     {
-      long sum = msg.A + msg.B;
       Console.WriteLine ("Incoming Service Request A=" + msg.A + " B=" + msg.B);
-      IntPtr psum = new IntPtr(sum);
-      my_service.SendResp(psum);
+      example_interfaces.srv.AddTwoInts_Response response = new example_interfaces.srv.AddTwoInts_Response();
+      response.Sum = msg.A + msg.B;
+      my_service.SendResp(response);
     }
   }
 }


### PR DESCRIPTION
Hello there,
I thought it might be more convenient for users if the service response is converted to an `intPtr` internally by the library.
Furthermore, doing so without an explicit call to `SendResp` would prevent misuse by users and threading issues.
The change was only tested on ROS2 Humble on Windows.