### PR TITLE
refactor Client

### DIFF
--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)
   execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs

--- a/src/ros2cs/ros2cs_common/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_common/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.0")
 
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)

--- a/src/ros2cs/ros2cs_common/Exceptions.cs
+++ b/src/ros2cs/ros2cs_common/Exceptions.cs
@@ -56,4 +56,20 @@ namespace ROS2
       public InvalidNamespaceException(string message) : base(message) {}
       public InvalidNamespaceException(string message, Exception inner) : base(message, inner) {}
     }
+    /// <summary>
+    /// Exception thrown when trying to wait on an empty wait set.
+    /// </summary>
+    public class WaitSetEmptyException : InvalidOperationException
+    {
+      public WaitSetEmptyException() : base()
+      { }
+
+      /// <inheritdoc />
+      public WaitSetEmptyException(string message) : base(message)
+      { }
+
+      /// <inheritdoc />
+      public WaitSetEmptyException(string message, Exception innerException) : base(message, innerException)
+      { }
+    }
 }

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.0")
 
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)

--- a/src/ros2cs/ros2cs_core/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_core/CMakeLists.txt
@@ -29,6 +29,8 @@ find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)
   execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -136,7 +136,7 @@ namespace ROS2
     public void TakeMessage()
     {
       MessageInternals msg = new O() as MessageInternals;
-      rcl_rmw_request_id_t request_header = default;
+      rcl_rmw_request_id_t request_header = default(rcl_rmw_request_id_t);
       int ret;
       lock (mutex)
       {
@@ -164,8 +164,8 @@ namespace ROS2
     /// <param name="header">sequence number received when sending the Request</param>
     private void ProcessResponse(long sequence_number, MessageInternals msg)
     {
-      bool exists = default;
-      TaskCompletionSource<O> source = default;
+      bool exists = default(bool);
+      TaskCompletionSource<O> source = default(TaskCompletionSource<O>);
       lock (Requests)
       {
         exists = Requests.Remove(sequence_number, out source);
@@ -188,7 +188,7 @@ namespace ROS2
     /// <returns>sequence number of the Request</returns>
     private long SendRequest(I msg)
     {
-      long sequence_number = default;
+      long sequence_number = default(long);
       MessageInternals msgInternals = msg as MessageInternals;
       msgInternals.WriteNativeMessage();
       Utils.CheckReturnEnum(

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -25,6 +25,9 @@ namespace ROS2
   public class Client<T>: IClient<T> where T : Message, new ()
   {
     public string Topic { get { return topic; } }
+
+    public rcl_client_t Handle { get { return serviceHandle; } }
+
     private string topic;
 
     public long Sequence_number { get { return sequence_number; } }
@@ -32,6 +35,10 @@ namespace ROS2
 
     public bool IsWait_flag { get { return wait_flag; } }
     private bool wait_flag;
+
+    public object Mutex { get { return mutex; } }
+
+    private object mutex = new object();
 
     private Ros2csLogger logger = Ros2csLogger.GetInstance();
     rcl_client_t serviceHandle;

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 using ROS2.Internal;
 
 
@@ -177,11 +177,15 @@ namespace ROS2
     /// <param name="header">sequence number received when sending the Request</param>
     private void ProcessResponse(long sequence_number, MessageInternals msg)
     {
-      bool exists = default(bool);
+      bool exists = false;
       (TaskCompletionSource<O>, Task<O>) source = default((TaskCompletionSource<O>, Task<O>));
       lock (Requests)
       {
-        exists = Requests.Remove(sequence_number, out source);
+        if (Requests.TryGetValue(sequence_number, out source))
+        {
+          exists = true;
+          Requests.Remove(sequence_number);
+        }
       }
       if (exists)
       {

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -191,7 +191,14 @@ namespace ROS2
       }
     }
 
-    public Task<O> SendAndRecv(I msg)
+    public O Call(I msg)
+    {
+      var task = CallAsync(msg);
+      task.Wait();
+      return task.Result;
+    }
+
+    public Task<O> CallAsync(I msg)
     {
       if (!Ros2cs.Ok() || disposed)
       {
@@ -203,7 +210,7 @@ namespace ROS2
       return source.Task;
     }
 
-    public Task<O> SendAndRecv(I msg, TaskCreationOptions options)
+    public Task<O> CallAsync(I msg, TaskCreationOptions options)
     {
       if (!Ros2cs.Ok() || disposed)
       {

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -59,7 +59,7 @@ namespace ROS2
 
       QualityOfServiceProfile qualityOfServiceProfile = qos;
       if (qualityOfServiceProfile == null)
-        qualityOfServiceProfile = new QualityOfServiceProfile();
+        qualityOfServiceProfile = new QualityOfServiceProfile(QosPresetProfile.SERVICES_DEFAULT);
 
       Requests = new Dictionary<long, TaskCompletionSource<O>>();
 

--- a/src/ros2cs/ros2cs_core/Client.cs
+++ b/src/ros2cs/ros2cs_core/Client.cs
@@ -110,21 +110,15 @@ namespace ROS2
       }
     }
 
-    /// <summary> Wait Service wakeup </summary>
-    public void WaitForService()
+    public bool IsServiceAvailable()
     {
-      bool wait_flag = false;
-      while (!wait_flag)
-      {
-        int ret = NativeRcl.rcl_service_server_is_available(
-          ref nodeHandle,
-          ref serviceHandle,
-          ref wait_flag
-        );
-        Utils.CheckReturnEnum(ret);
-        logger.LogInfo("Waiting for server startup");
-        System.Threading.Thread.Sleep(1000);
-      }
+      bool available = false;
+      Utils.CheckReturnEnum(NativeRcl.rcl_service_server_is_available(
+        ref nodeHandle,
+        ref serviceHandle,
+        ref available
+      ));
+      return available;
     }
 
     public void TakeMessage()

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -37,6 +37,17 @@ namespace ROS2
       }
     }
 
+    internal List<IClientBase> Clients
+    {
+      get
+      {
+        lock (mutex)
+        {
+          return clients.ToList();
+        }
+      }
+    }
+
     internal List<IServiceBase> Services
     {
       get
@@ -132,7 +143,7 @@ namespace ROS2
 
     /// <summary> Create a client for this node for a given topic, qos and message type </summary>
     /// <see cref="INode.CreateClient"/>
-    public Client<T> CreateClient<T>(string topic, QualityOfServiceProfile qos = null) where T : Message, new()
+    public Client<I, O> CreateClient<I, O>(string topic, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new()
     {
       lock (mutex)
       {
@@ -142,7 +153,7 @@ namespace ROS2
           return null;
         }
 
-        Client<T> client = new Client<T>(topic, this, qos);
+        Client<I, O> client = new Client<I, O>(topic, this, qos);
         clients.Add(client);
         logger.LogInfo("Created Client for topic " + topic);
         return client;

--- a/src/ros2cs/ros2cs_core/Node.cs
+++ b/src/ros2cs/ros2cs_core/Node.cs
@@ -168,6 +168,7 @@ namespace ROS2
         if (clients.Contains(client))
         {
           logger.LogInfo("Removing client for topic " + client.Topic);
+          client.Dispose();
           return clients.Remove(client);
         }
         return false;
@@ -202,6 +203,7 @@ namespace ROS2
         if (services.Contains(service))
         {
           logger.LogInfo("Removing service for topic " + service.Topic);
+          service.Dispose();
           return services.Remove(service);
         }
         return false;

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -101,7 +101,7 @@ namespace ROS2
     public void TakeMessage()
     {
       RCLReturnEnum ret;
-      rcl_rmw_request_id_t header = default;
+      rcl_rmw_request_id_t header = default(rcl_rmw_request_id_t);
       MessageInternals message;
 
       lock (mutex)

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -17,83 +17,44 @@ using ROS2.Internal;
 
 namespace ROS2
 {
-  /// <summary> Service to a topic with a given type </summary>
-  /// <description> Services are created through INode interface (CreateService) </description>
-  public class Service<I, O>: IService<I, O>
+    /// <summary>Service with a topic and Types for Messages</summary>
+    /// <remarks>Instances are created by <see cref="INode.CreateService"/></remarks>
+    /// <typeparam name="I">Message Type to be received</typeparam>
+    /// <typeparam name="O">Message Type to be send</typeparam>
+    public class Service<I, O>: IService<I, O>
     where I : Message, new ()
     where O : Message, new ()
   {
     public rcl_service_t Handle { get { return serviceHandle; } }
     private rcl_service_t serviceHandle;
 
+    /// <summary>
+    /// Topic of this Service
+    /// </summary>
     public string Topic { get { return topic; } }
     private string topic;
 
+    /// <inheritdoc/>
     public bool IsDisposed { get { return disposed; } }
     private bool disposed = false;
 
+    /// <inheritdoc/>
     private rcl_node_t nodeHandle;
+
+    /// <summary>
+    /// Callback to be called to process incoming requests
+    /// </summary>
     private readonly Func<I, O> callback;
     private IntPtr serviceOptions;
 
+    /// <inheritdoc/>
     public object Mutex { get { return mutex; } }
     private object mutex = new object();
 
-    /// <summary> Tries to send a response message to rcl/rmw layers. </summary>
-    // TODO(adamdbrw) this should not be public - add an internal interface
-    private void SendResp(rcl_rmw_request_id_t header, O msg)
-    {
-      RCLReturnEnum ret;
-      MessageInternals msgInternals = msg as MessageInternals;
-
-      msgInternals.WriteNativeMessage();
-      ret = (RCLReturnEnum)NativeRcl.rcl_send_response(ref serviceHandle, ref header, msgInternals.Handle);
-    }
-
-    /// <summary> Tries to get a request message from rcl/rmw layers. Calls the callback if successful </summary>
-    // TODO(adamdbrw) this should not be public - add an internal interface
-    public void TakeMessage()
-    {
-      RCLReturnEnum ret;
-      rcl_rmw_request_id_t header = default;
-      MessageInternals message;
-
-      lock (mutex)
-      {
-        if (disposed || !Ros2cs.Ok())
-        {
-          return;
-        }
-        message = CreateMessage();
-
-        ret = (RCLReturnEnum)NativeRcl.rcl_take_request(ref serviceHandle, ref header,  message.Handle);
-      }
-
-      bool gotMessage = ret == RCLReturnEnum.RCL_RET_OK;
-
-      if (gotMessage)
-      {
-        TriggerCallback(header, message);
-      }
-    }
-
-    /// <summary> Construct a message of the subscription type </summary>
-    private MessageInternals CreateMessage()
-    {
-      return new I() as MessageInternals;
-    }
-
-    /// <summary> Populates managed fields with native values and calls the callback with created message </summary>
-    /// <param name="message"> Message that will be populated and returned through callback </param>
-    private void TriggerCallback(rcl_rmw_request_id_t header, MessageInternals message)
-    {
-      message.ReadNativeMessage();
-      O response = callback((I)message);
-      SendResp(header, response);
-    }
-
-    /// <summary> Internal constructor for Service. Use INode.CreateService to construct </summary>
-    /// <see cref="INode.CreateService"/>
+    /// <summary>
+    /// Internal constructor for Service
+    /// </summary>
+    /// <remarks>Use <see cref="INode.CreateService"/> to construct new Instances</remarks>
     internal Service(string subTopic, Node node, Func<I, O> cb, QualityOfServiceProfile qos = null)
     {
       callback = cb;
@@ -120,6 +81,57 @@ namespace ROS2
         typeSupportHandle,
         topic,
         serviceOptions));
+    }
+
+    /// <summary>
+    /// Send Response Message with rcl/rmw layers
+    /// </summary>
+    /// <param name="header">request id received when taking the Request</param>
+    /// <param name="msg">Message to be send</param>
+    private void SendResp(rcl_rmw_request_id_t header, O msg)
+    {
+      RCLReturnEnum ret;
+      MessageInternals msgInternals = msg as MessageInternals;
+      msgInternals.WriteNativeMessage();
+      ret = (RCLReturnEnum)NativeRcl.rcl_send_response(ref serviceHandle, ref header, msgInternals.Handle);
+    }
+
+    /// <inheritdoc/>
+    // TODO(adamdbrw) this should not be public - add an internal interface
+    public void TakeMessage()
+    {
+      RCLReturnEnum ret;
+      rcl_rmw_request_id_t header = default;
+      MessageInternals message;
+
+      lock (mutex)
+      {
+        if (disposed || !Ros2cs.Ok())
+        {
+          return;
+        }
+        message = new I() as MessageInternals;
+
+        ret = (RCLReturnEnum)NativeRcl.rcl_take_request(ref serviceHandle, ref header,  message.Handle);
+      }
+
+      if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_OK)
+      {
+        ProcessRequest(header, message);
+      }
+    }
+
+    /// <summary>
+    /// Populates managed fields with native values and calls the callback with the created message
+    /// </summary>
+    /// <remarks>Sending the Response is also takes care of by this method</remarks>
+    /// <param name="message">Message that will be populated and provided to the callback</param>
+    /// <param name="header">request id received when taking the Request</param>
+    private void ProcessRequest(rcl_rmw_request_id_t header, MessageInternals message)
+    {
+      message.ReadNativeMessage();
+      O response = callback((I)message);
+      SendResp(header, response);
     }
 
     ~Service()

--- a/src/ros2cs/ros2cs_core/Service.cs
+++ b/src/ros2cs/ros2cs_core/Service.cs
@@ -104,7 +104,7 @@ namespace ROS2
       QualityOfServiceProfile qualityOfServiceProfile = qos;
       if (qualityOfServiceProfile == null)
       {
-        qualityOfServiceProfile = new QualityOfServiceProfile();
+        qualityOfServiceProfile = new QualityOfServiceProfile(QosPresetProfile.SERVICES_DEFAULT);
       }
 
       serviceOptions = NativeRclInterface.rclcs_service_create_options(qualityOfServiceProfile.handle);

--- a/src/ros2cs/ros2cs_core/WaitSet.cs
+++ b/src/ros2cs/ros2cs_core/WaitSet.cs
@@ -72,13 +72,13 @@ namespace ROS2
 
     internal AddResult TryAddSubscription(ISubscriptionBase subscription, out ulong index)
     {
-      UIntPtr native_index = default;
+      UIntPtr native_index = default(UIntPtr);
       int ret;
       lock (subscription.Mutex)
       {
         if (subscription.IsDisposed)
         {
-          index = default;
+          index = default(ulong);
           return AddResult.DISPOSED;
         }
 
@@ -92,7 +92,7 @@ namespace ROS2
 
       if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
       {
-        index = default;
+        index = default(ulong);
         return AddResult.FULL;
       }
       else
@@ -105,13 +105,13 @@ namespace ROS2
 
     internal AddResult TryAddClient(IClientBase client, out ulong index)
     {
-      UIntPtr native_index = default;
+      UIntPtr native_index = default(UIntPtr);
       int ret;
       lock (client.Mutex)
       {
         if (client.IsDisposed)
         {
-          index = default;
+          index = default(ulong);
           return AddResult.DISPOSED;
         }
 
@@ -125,7 +125,7 @@ namespace ROS2
       
       if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
       {
-        index = default;
+        index = default(ulong);
         return AddResult.FULL;
       }
       else
@@ -138,14 +138,14 @@ namespace ROS2
 
     internal AddResult TryAddService(IServiceBase service, out ulong index)
     {
-      UIntPtr native_index = default;
+      UIntPtr native_index = default(UIntPtr);
       int ret;
 
       lock (service.Mutex)
       {
         if (service.IsDisposed)
         {
-          index = default;
+          index = default(ulong);
           return AddResult.DISPOSED;
         }
 
@@ -160,7 +160,7 @@ namespace ROS2
 
       if ((RCLReturnEnum)ret == RCLReturnEnum.RCL_RET_WAIT_SET_FULL)
       {
-        index = default;
+        index = default(ulong);
         return AddResult.FULL;
       }
       else

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -22,6 +22,10 @@ namespace ROS2
   public interface IClientBase: IExtendedDisposable
   {
     string Topic {get;}
+
+    rcl_client_t Handle {get;}
+
+    object Mutex { get; }
   }
 
   /// <summary> Generic base interface for all subscriptions </summary>

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -41,8 +41,10 @@ namespace ROS2
     /// <summary> Service a message </summary>
     /// <description> Message memory is copied into native structures and the message
     /// can be safely changed or disposed after this call </description>
-    Task<O> SendAndRecv(I msg);
+    O Call(I msg);
 
-    Task<O> SendAndRecv(I msg, TaskCreationOptions options);
+    Task<O> CallAsync(I msg);
+
+    Task<O> CallAsync(I msg, TaskCreationOptions options);
   }
 }

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading.Tasks;
 
 namespace ROS2
 {
@@ -21,6 +22,9 @@ namespace ROS2
   /// This interface is useful for managing service collections and disposal </description>
   public interface IClientBase: IExtendedDisposable
   {
+    // TODO this should not be public - add an internal interface
+    void TakeMessage();
+
     string Topic {get;}
 
     rcl_client_t Handle {get;}
@@ -29,13 +33,16 @@ namespace ROS2
   }
 
   /// <summary> Generic base interface for all subscriptions </summary>
-  public interface IClient<T>: IClientBase
-      where T: Message
+  public interface IClient<I, O>: IClientBase
+      where I: Message
+      where O: Message
   {
-    void WaitForService(T msg);
+    void WaitForService();
     /// <summary> Service a message </summary>
     /// <description> Message memory is copied into native structures and the message
     /// can be safely changed or disposed after this call </description>
-    IntPtr SendAndRecv(T msg);
+    Task<O> SendAndRecv(I msg);
+
+    Task<O> SendAndRecv(I msg, TaskCreationOptions options);
   }
 }

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace ROS2
@@ -35,6 +35,21 @@ namespace ROS2
     /// </summary>
     string Topic {get;}
 
+    /// <summary>
+    /// Requests which are pending for this client.
+    /// </summary>
+    IReadOnlyDictionary<long, Task> PendingRequests {get;}
+
+    /// <summary>
+    /// Remove a pending <see cref="Task"/> and cancel it.
+    /// </summary>
+    /// <remarks>
+    /// Tasks are automatically removed on completion and have to be removed only when canceled.
+    /// </remarks>
+    /// <param name="task">Task to be removed.</param>
+    /// <returns>Whether the Task was removed successfully.</returns>
+    bool Cancel(Task task);
+
     rcl_client_t Handle {get;}
 
     /// <summary> service mutex for internal use </summary>
@@ -49,6 +64,11 @@ namespace ROS2
       where I: Message
       where O: Message
   {
+    /// <summary>
+    /// Requests which are pending for this client.
+    /// </summary>
+    new IReadOnlyDictionary<long, Task<O>> PendingRequests {get;}
+
     /// <summary>
     /// Check if the service to be called is available
     /// </summary>

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -37,7 +37,7 @@ namespace ROS2
       where I: Message
       where O: Message
   {
-    void WaitForService();
+    bool IsServiceAvailable();
     /// <summary> Service a message </summary>
     /// <description> Message memory is copied into native structures and the message
     /// can be safely changed or disposed after this call </description>

--- a/src/ros2cs/ros2cs_core/interfaces/IClient.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IClient.cs
@@ -18,33 +18,60 @@ using System.Threading.Tasks;
 namespace ROS2
 {
   /// <summary> Non-generic base interface for all subscriptions </summary>
-  /// <description> Use Ros2cs.CreateClient to construct.
-  /// This interface is useful for managing service collections and disposal </description>
+  /// <seealso cref="INode.CreateClient"/>
   public interface IClientBase: IExtendedDisposable
   {
+    /// <summary>
+    /// Tries to get a Response message from rcl/rmw layers
+    /// </summary>
+    /// <remarks>
+    /// Marks the corresponding <see cref="Task"/> as finished if successful
+    /// </remarks>
     // TODO this should not be public - add an internal interface
     void TakeMessage();
 
+    /// <summary>
+    /// topic name which was used when calling <see cref="INode.CreateClient"/>
+    /// </summary>
     string Topic {get;}
 
     rcl_client_t Handle {get;}
 
+    /// <summary> service mutex for internal use </summary>
     object Mutex { get; }
   }
 
   /// <summary> Generic base interface for all subscriptions </summary>
+  /// <typeparam name="I">Message Type to be send</typeparam>
+  /// <typeparam name="O">Message Type to be received</typeparam>
+  /// <seealso cref="INode.CreateClient"/>
   public interface IClient<I, O>: IClientBase
       where I: Message
       where O: Message
   {
+    /// <summary>
+    /// Check if the service to be called is available
+    /// </summary>
+    /// <returns><see cref="true"/> if the service is avilable</returns>
     bool IsServiceAvailable();
-    /// <summary> Service a message </summary>
-    /// <description> Message memory is copied into native structures and the message
-    /// can be safely changed or disposed after this call </description>
+
+    /// <summary>
+    /// Send a Request to a Service and wait for a Response
+    /// </summary>
+    /// <remarks>The provided message can be modified or disposed after this call</remarks>
+    /// <param name="msg">Message to be send</param>
+    /// <returns>Response of the Service</returns>
     O Call(I msg);
 
+    /// <summary>
+    /// Send a Request to a Service and wait for a Response asynchronously
+    /// </summary>
+    /// <param name="msg">Message to be send</param>
+    /// <returns><see cref="Task"/> representing the Response of the Service</returns>
     Task<O> CallAsync(I msg);
 
+    /// <inheritdoc cref="CallAsync(I)"/>
+    /// <param name="options">Options used when creating the <see cref="Task"/></param>
     Task<O> CallAsync(I msg, TaskCreationOptions options);
   }
 }

--- a/src/ros2cs/ros2cs_core/interfaces/INode.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/INode.cs
@@ -31,7 +31,7 @@ namespace ROS2
     /// <param name="topic"> Topic for the client. Naming restrictions of ros2 apply and violation results in an exception </param>
     /// <param name="qos"> Quality of Client settings. Not passing this parameter will result in default settings </param>
     /// <returns> Client for the topic, which can be used to client messages </returns>
-    Client<T> CreateClient<T>(string topic, QualityOfServiceProfile qos = null) where T : Message, new();
+    Client<I, O> CreateClient<I, O>(string topic, QualityOfServiceProfile qos = null) where I : Message, new() where O : Message, new();
 
     /// <summary> Remove a client </summary>
     /// <remarks> Note that this does not call Dispose on Client </remarks>

--- a/src/ros2cs/ros2cs_core/interfaces/IService.cs
+++ b/src/ros2cs/ros2cs_core/interfaces/IService.cs
@@ -17,13 +17,19 @@ using System;
 namespace ROS2
 {
   /// <summary> Non-generic base interface for all subscriptions </summary>
-  /// <description> Use Ros2cs.CreateSubscription to construct </description>
+  /// <seealso cref="INode.CreateService"/>
   public interface IServiceBase : IExtendedDisposable
   {
+    /// <summary>
+    /// Tries to get a request message from rcl/rmw layers
+    /// </summary>
+    /// <remarks>Invokes the callback if successful</remarks>
     // TODO(adamdbrw) this should not be public - add an internal interface
     void TakeMessage();
 
-    /// <summary> topic name which was used when calling Ros2cs.CreateService </summary>
+    /// <summary>
+    /// topic name which was used when calling <see cref="INode.CreateService"/>
+    /// </summary>
     string Topic {get;}
 
     // TODO(adamdbrw) this should not be public - add an internal interface
@@ -34,6 +40,9 @@ namespace ROS2
   }
 
   /// <summary> Generic base interface for all services </summary>
+  /// <typeparam name="I">Message Type to be received</typeparam>
+  /// <typeparam name="O">Message Type to be send</typeparam>
+  /// <seealso cref="INode.CreateService"/>
   public interface IService<I, O>: IServiceBase
     where I: Message
     where O: Message

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -180,7 +180,7 @@ namespace ROS2
         typeof(SendRequestType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int TakeResponceType(ref rcl_client_t client, ref rcl_rmw_request_id_t request_header, ref IntPtr responce_info);
+    internal delegate int TakeResponceType(ref rcl_client_t client, ref rcl_rmw_request_id_t request_header, IntPtr ros_response);
     internal static TakeResponceType
         rcl_take_response =
         (TakeResponceType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(

--- a/src/ros2cs/ros2cs_core/native/NativeRcl.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeRcl.cs
@@ -352,13 +352,27 @@ namespace ROS2
         typeof(GetZeroInitializedWaitSetType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate int WaitSetResizeType(ref rcl_wait_set_t wait_set,
+                                            UIntPtr number_of_subscriptions,
+                                            UIntPtr number_of_guard_conditions,
+                                            UIntPtr number_of_timers,
+                                            UIntPtr number_of_clients,
+                                            UIntPtr number_of_services,
+                                            UIntPtr number_of_events);
+    internal static WaitSetResizeType rcl_wait_set_resize =
+        (WaitSetResizeType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+        nativeRCL,
+        "rcl_wait_set_resize"),
+        typeof(WaitSetResizeType));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate int WaitSetInitType(ref rcl_wait_set_t wait_set,
-                                          ulong number_of_subscriptions,
-                                          ulong number_of_guard_conditions,
-                                          ulong number_of_timers,
-                                          ulong number_of_clients,
-                                          ulong number_of_services,
-                                          ulong number_of_events,
+                                          UIntPtr number_of_subscriptions,
+                                          UIntPtr number_of_guard_conditions,
+                                          UIntPtr number_of_timers,
+                                          UIntPtr number_of_clients,
+                                          UIntPtr number_of_services,
+                                          UIntPtr number_of_events,
                                           ref rcl_context_t context,
                                           rcl_allocator_t allocator);
     internal static WaitSetInitType
@@ -387,7 +401,7 @@ namespace ROS2
         typeof(WaitSetClearType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int WaitSetAddSubscriptionType(ref rcl_wait_set_t wait_set, ref rcl_subscription_t subscription, UIntPtr index);
+    internal delegate int WaitSetAddSubscriptionType(ref rcl_wait_set_t wait_set, ref rcl_subscription_t subscription, ref UIntPtr index);
     internal static WaitSetAddSubscriptionType
         rcl_wait_set_add_subscription =
         (WaitSetAddSubscriptionType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
@@ -396,7 +410,25 @@ namespace ROS2
         typeof(WaitSetAddSubscriptionType));
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate int WaitType(ref rcl_wait_set_t wait_set, ulong timeout);
+    internal delegate int WaitSetAddClientType(ref rcl_wait_set_t wait_set, ref rcl_client_t client, ref UIntPtr index);
+    internal static WaitSetAddClientType
+        rcl_wait_set_add_client =
+        (WaitSetAddClientType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+        nativeRCL,
+        "rcl_wait_set_add_client"),
+        typeof(WaitSetAddClientType));
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate int WaitSetAddServiceType(ref rcl_wait_set_t wait_set, ref rcl_service_t service, ref UIntPtr index);
+    internal static WaitSetAddServiceType
+        rcl_wait_set_add_service =
+        (WaitSetAddServiceType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+        nativeRCL,
+        "rcl_wait_set_add_service"),
+        typeof(WaitSetAddServiceType));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate int WaitType(ref rcl_wait_set_t wait_set, long timeout);
     internal static WaitType
         rcl_wait =
         (WaitType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(

--- a/src/ros2cs/ros2cs_core/native/NativeTypes.cs
+++ b/src/ros2cs/ros2cs_core/native/NativeTypes.cs
@@ -99,17 +99,17 @@ namespace ROS2
   public struct rcl_wait_set_t
   {
     private IntPtr subscriptions;
-    private UIntPtr size_of_subscriptions;
+    internal UIntPtr size_of_subscriptions;
     private IntPtr guard_conditions;
-    private UIntPtr size_of_guard_conditions;
+    internal UIntPtr size_of_guard_conditions;
     private IntPtr timers;
-    private UIntPtr size_of_timers;
+    internal UIntPtr size_of_timers;
     private IntPtr clients;
-    private UIntPtr size_of_clients;
+    internal UIntPtr size_of_clients;
     private IntPtr services;
-    private UIntPtr size_of_services;
+    internal UIntPtr size_of_services;
     private IntPtr events;
-    private UIntPtr size_of_events;
+    internal UIntPtr size_of_events;
     private IntPtr impl;
   }
 

--- a/src/ros2cs/ros2cs_core/ros2cs_core.csproj
+++ b/src/ros2cs/ros2cs_core/ros2cs_core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/ros2cs/ros2cs_core/utils/Utils.cs
+++ b/src/ros2cs/ros2cs_core/utils/Utils.cs
@@ -33,6 +33,8 @@ namespace ROS2
           throw new InvalidNodeNameException(errorMessage);
         case RCLReturnEnum.RCL_RET_NODE_INVALID_NAMESPACE:
           throw new InvalidNamespaceException(errorMessage);
+        case RCLReturnEnum.RCL_RET_WAIT_SET_EMPTY:
+          throw new WaitSetEmptyException(errorMessage);
         default:
           throw new RuntimeError(errorMessage);
       }

--- a/src/ros2cs/ros2cs_examples/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_examples/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(rosidl_generator_cs REQUIRED)
 
-set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.0")
 
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)

--- a/src/ros2cs/ros2cs_examples/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_examples/CMakeLists.txt
@@ -26,6 +26,8 @@ find_package(builtin_interfaces REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(rosidl_generator_cs REQUIRED)
 
+set(CSHARP_TARGET_FRAMEWORK "netstandard2.1")
+
 if(UNIX)
   find_program(LSB_RELEASE_EXEC lsb_release)
   execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs

--- a/src/ros2cs/ros2cs_examples/ROS2Client.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Client.cs
@@ -38,9 +38,8 @@ namespace Examples
 
       my_client.WaitForService();
 
-      Task<example_interfaces.srv.AddTwoInts_Response> rsp = my_client.SendAndRecv(msg);
-      rsp.Wait();
-      Console.WriteLine("Sum = " + rsp.Result.Sum);
+      example_interfaces.srv.AddTwoInts_Response rsp = my_client.Call(msg);
+      Console.WriteLine("Sum = " + rsp.Sum);
 
       Console.WriteLine("Client shutdown");
       Ros2cs.Shutdown();

--- a/src/ros2cs/ros2cs_examples/ROS2Client.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Client.cs
@@ -14,7 +14,7 @@
 
 
 using System;
-using System.Threading;
+using System.Threading.Tasks;
 using ROS2;
 using std_msgs;
 using sensor_msgs;
@@ -30,18 +30,17 @@ namespace Examples
       Console.WriteLine("Client start");
       Ros2cs.Init();
       INode node = Ros2cs.CreateNode("talker");
-      Client<example_interfaces.srv.AddTwoInts_Request> my_client = node.CreateClient<example_interfaces.srv.AddTwoInts_Request>("add_two_ints");
+      Client<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response> my_client = node.CreateClient<example_interfaces.srv.AddTwoInts_Request, example_interfaces.srv.AddTwoInts_Response>("add_two_ints");
 
       example_interfaces.srv.AddTwoInts_Request msg = new example_interfaces.srv.AddTwoInts_Request();
       msg.A = 7;
       msg.B = 2;
 
-      my_client.WaitForService(msg);
+      my_client.WaitForService();
 
-      IntPtr ptr;
-      ptr = my_client.SendAndRecv(msg);
-      int sum = (int)ptr;
-      Console.WriteLine("Sum = " + sum);
+      Task<example_interfaces.srv.AddTwoInts_Response> rsp = my_client.SendAndRecv(msg);
+      rsp.Wait();
+      Console.WriteLine("Sum = " + rsp.Result.Sum);
 
       Console.WriteLine("Client shutdown");
       Ros2cs.Shutdown();

--- a/src/ros2cs/ros2cs_examples/ROS2Client.cs
+++ b/src/ros2cs/ros2cs_examples/ROS2Client.cs
@@ -14,7 +14,7 @@
 
 
 using System;
-using System.Threading.Tasks;
+using System.Threading;
 using ROS2;
 using std_msgs;
 using sensor_msgs;
@@ -36,7 +36,10 @@ namespace Examples
       msg.A = 7;
       msg.B = 2;
 
-      my_client.WaitForService();
+      while (!my_client.IsServiceAvailable())
+      {
+        Thread.Sleep(TimeSpan.FromSeconds(0.25));
+      }
 
       example_interfaces.srv.AddTwoInts_Response rsp = my_client.Call(msg);
       Console.WriteLine("Sum = " + rsp.Sum);

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BUILD_TESTING)
 
   find_package(std_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
+  find_package(example_interfaces REQUIRED)
 
   set(DOTNET_OUTPUT_PATH
     ${CSHARP_BUILDER_OUTPUT_PATH}/${CSHARP_TARGET_FRAMEWORK}/
@@ -34,6 +35,7 @@ if(BUILD_TESTING)
       ${ros2cs_common_ASSEMBLIES_DLL}
       ${std_msgs_ASSEMBLIES_DLL}
       ${test_msgs_ASSEMBLIES_DLL}
+      ${example_interfaces_ASSEMBLIES_DLL}
   )
 
   set(TESTS_SRC
@@ -44,6 +46,7 @@ if(BUILD_TESTING)
     src/MessagesTest.cs
     src/NodeTest.cs
     src/NativeMetodsTest.cs
+    src/ClientTest.cs
     src/SubscriptionTest.cs
     src/TestUtils.cs
   )

--- a/src/ros2cs/ros2cs_tests/CMakeLists.txt
+++ b/src/ros2cs/ros2cs_tests/CMakeLists.txt
@@ -47,6 +47,7 @@ if(BUILD_TESTING)
     src/NodeTest.cs
     src/NativeMetodsTest.cs
     src/ClientTest.cs
+    src/ServiceTest.cs
     src/SubscriptionTest.cs
     src/TestUtils.cs
   )

--- a/src/ros2cs/ros2cs_tests/package.xml
+++ b/src/ros2cs/ros2cs_tests/package.xml
@@ -13,10 +13,13 @@
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <build_depend>ros2cs_core</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <test_depend>ros2cs_core</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
+  <test_depend>example_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/ros2cs/ros2cs_tests/src/ClientTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClientTest.cs
@@ -1,0 +1,130 @@
+// Copyright 2019-2021 Robotec.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using example_interfaces.srv;
+
+namespace ROS2.Test
+{
+    [TestFixture]
+    public class ClientTest
+    {
+        private static readonly string SERVICE_NAME = "test_service";
+
+        private INode Node;
+
+        private IClient<AddTwoInts_Request, AddTwoInts_Response> Client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Ros2cs.Init();
+            Node = Ros2cs.CreateNode("service_test_node");
+            Client = Node.CreateClient<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Node.Dispose();
+            Ros2cs.Shutdown();
+        }
+
+        private AddTwoInts_Request CreateRequest(int a, int b)
+        {
+            var msg = new AddTwoInts_Request();
+            msg.A = a;
+            msg.B = b;
+            return msg;
+        }
+
+        private AddTwoInts_Response HandleRequest(AddTwoInts_Request msg)
+        {
+            var response = new AddTwoInts_Response();
+            response.Sum = msg.A + msg.B;
+            return response;
+        }
+
+        [Test]
+        public void ClientCallAsync()
+        {
+            using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                HandleRequest
+            );
+            var task = Client.CallAsync(CreateRequest(42, 3));
+            while (!task.IsCompleted)
+            {
+                Ros2cs.SpinOnce(Node, 0.1);
+            }
+            Assert.That(task.Result.Sum, Is.EqualTo(45));
+        }
+
+        [Test]
+        public void ClientCallAsyncConcurrent()
+        {
+            using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                HandleRequest
+            );
+            Task<AddTwoInts_Response>[] tasks = Enumerable
+                .Range(0, 10)
+                .Select(i => Client.CallAsync(CreateRequest(i, 100 - i)))
+                .ToArray();
+            while (!tasks.All(task => task.IsCompleted))
+            {
+                Ros2cs.SpinOnce(Node, 0.1);
+            }
+            Assert.That(tasks.Select(task => task.Result.Sum), Is.All.EqualTo(100));
+        }
+
+        [Test]
+        public void DisposedClientHandling()
+        {
+            Assert.That(!Client.IsDisposed);
+            Client.Dispose();
+            Assert.That(Client.IsDisposed);
+            Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+
+        [Test]
+        public void DisposedClientTasks()
+        {
+            Ros2cs.SpinOnce(Node, 0.1);
+            using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                SERVICE_NAME,
+                HandleRequest
+            );
+            var task = Client.CallAsync(CreateRequest(42, 3));
+            Client.Dispose();
+
+            Assert.That(Client.IsDisposed);
+            Assert.Throws<AggregateException>(task.Wait);
+            Assert.That(task.IsFaulted);
+            Assert.That(task.Exception.InnerExceptions.Any(e => e is ObjectDisposedException));
+            Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+
+        [Test]
+        public void ReinitializeDisposedClient()
+        {
+            Client.Dispose();
+            Client = Node.CreateClient<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME);
+            Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+    }
+}

--- a/src/ros2cs/ros2cs_tests/src/ClientTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ClientTest.cs
@@ -93,6 +93,20 @@ namespace ROS2.Test
         }
 
         [Test]
+        public void ClientWaitForService()
+        {
+            Assert.That(!Client.IsServiceAvailable());
+            {
+                using var service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                    SERVICE_NAME,
+                    HandleRequest
+                );
+                Assert.That(Client.IsServiceAvailable());
+            }
+            Assert.That(!Client.IsServiceAvailable());
+        }
+
+        [Test]
         public void DisposedClientHandling()
         {
             Assert.That(!Client.IsDisposed);

--- a/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/InitShutdownTest.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using NUnit.Framework;
 
 namespace ROS2.Test
@@ -69,6 +70,26 @@ namespace ROS2.Test
         public void CreateNodeWithoutInit()
         {
             Assert.That(() => { Ros2cs.CreateNode("foo"); }, Throws.TypeOf<NotInitializedException>());
+        }
+
+        [Test]
+        public void SpinEmptyNode()
+        {
+            Ros2cs.Init();
+            try
+            {
+                var node = Ros2cs.CreateNode("TestNode");
+                Assert.That(Ros2cs.SpinOnce(node), Is.False);
+                var subscription = node.CreateSubscription<std_msgs.msg.Int32>(
+                    "subscription_test_topic",
+                    (msg) => { throw new InvalidOperationException("subscription callback was triggered"); }
+                );
+                Assert.That(Ros2cs.SpinOnce(node), Is.True);
+            }
+            finally
+            {
+                Ros2cs.Shutdown();
+            }
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/NativeMetodsTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NativeMetodsTest.cs
@@ -427,13 +427,25 @@ namespace ROS2.TestNativeMethods
 
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeRcl.rcl_get_zero_initialized_wait_set();
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
+            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(
+                ref waitSet,
+                (UIntPtr)1,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                ref context,
+                allocator
+            ));
             TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
 
             Assert.That(NativeRcl.rcl_subscription_is_valid(ref subscription), Is.True);
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_add_subscription(ref waitSet, ref subscription, UIntPtr.Zero));
+            UIntPtr index = (UIntPtr)42;
+            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_add_subscription(ref waitSet, ref subscription, ref index));
+            Assert.That(index.ToUInt64(), Is.EqualTo(0));
 
-            ulong timeout_ns = 10*1000*1000;
+            long timeout_ns = 10*1000*1000;
             var ret = (RCLReturnEnum)NativeRcl.rcl_wait(ref waitSet, timeout_ns);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_TIMEOUT));
         }
@@ -474,7 +486,17 @@ namespace ROS2.TestNativeMethods
         {
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeRcl.rcl_get_zero_initialized_wait_set();
-            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
+            TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_init(
+                ref waitSet,
+                (UIntPtr)1,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                ref context,
+                allocator
+            ));
             TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_fini(ref waitSet));
         }
 
@@ -483,7 +505,17 @@ namespace ROS2.TestNativeMethods
         {
             rcl_allocator_t allocator = NativeRcl.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeRcl.rcl_get_zero_initialized_wait_set();
-            NativeRcl.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator);
+            NativeRcl.rcl_wait_set_init(
+                ref waitSet,
+                (UIntPtr)1,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                (UIntPtr)0,
+                ref context,
+                allocator
+            );
             TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_clear(ref waitSet));
             TestUtils.AssertRetOk(NativeRcl.rcl_wait_set_fini(ref waitSet));
         }

--- a/src/ros2cs/ros2cs_tests/src/NodeTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/NodeTest.cs
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using NUnit.Framework;
 using System;
+using NUnit.Framework;
+using example_interfaces.srv;
 
 namespace ROS2.Test
 {
@@ -107,6 +108,27 @@ namespace ROS2.Test
                 "test_topic", msg => Console.WriteLine("Got message")))
             {
             }
+        }
+
+        [Test]
+        public void RemoveService()
+        {
+            var service = node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(
+                "/test",
+                request => { throw new InvalidOperationException("service should not be called"); }
+            );
+            
+            Assert.That(node.RemoveService(service));
+            Assert.That(service.IsDisposed);
+        }
+
+        [Test]
+        public void RemoveClient()
+        {
+            var client = node.CreateClient<AddTwoInts_Request, AddTwoInts_Response>("/test");
+            
+            Assert.That(node.RemoveClient(client));
+            Assert.That(client.IsDisposed);
         }
     }
 }

--- a/src/ros2cs/ros2cs_tests/src/ServiceTest.cs
+++ b/src/ros2cs/ros2cs_tests/src/ServiceTest.cs
@@ -1,0 +1,65 @@
+// Copyright 2019-2021 Robotec.ai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using NUnit.Framework;
+using example_interfaces.srv;
+
+namespace ROS2.Test
+{
+    [TestFixture]
+    public class ServiceTest
+    {
+        private static readonly string SERVICE_NAME = "test_service";
+
+        private INode Node;
+
+        private IService<AddTwoInts_Request, AddTwoInts_Response> Service;
+
+        private Func<AddTwoInts_Request, AddTwoInts_Response> OnRequest =
+            msg => throw new InvalidOperationException("callback not set");
+
+        [SetUp]
+        public void SetUp()
+        {
+            Ros2cs.Init();
+            Node = Ros2cs.CreateNode("service_test_node");
+            Service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME, OnRequest);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Node.Dispose();
+            Ros2cs.Shutdown();
+        }
+
+        [Test]
+        public void DisposedServiceHandling()
+        {
+            Assert.That(!Service.IsDisposed);
+            Service.Dispose();
+            Assert.That(Service.IsDisposed);
+            Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+
+        [Test]
+        public void ReinitializeDisposedService()
+        {
+            Service.Dispose();
+            Service = Node.CreateService<AddTwoInts_Request, AddTwoInts_Response>(SERVICE_NAME, OnRequest);
+            Assert.DoesNotThrow(() => { Ros2cs.SpinOnce(Node, 0.1); });
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I took a look at the current `Client` implementation and found a few opportunities for improvement:

| Change                                         | Reason                                                                           |
|------------------------------------------------|----------------------------------------------------------------------------------|
| refactor WaitSet                               | allow waiting for Clients                                                        |
| return a Task containing the Response          | allow for async waiting, prevents deadlocks when both Client and Service run in Unity |
| replace WaitForService with IsServiceAvailable | allow users to handle polling themselves, for example using `WaitUntil` in Unity |
| change default Qos Profile to SERVICES_DEFAULT |  seems to be [defined](https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html#qos-profiles) specifically for services|
| add tests and documentation                    |                                                                                  |

The changes where only tested on ROS2 Humble on Windows.

You commented on the last PR that you where not having enough time, I could create a separate PR containing your changes (with attributions of course) on `RobotecAI/ros2cs` if you want.